### PR TITLE
Ignore safe area insets

### DIFF
--- a/iOS/src/toga_iOS/widgets/webview.py
+++ b/iOS/src/toga_iOS/widgets/webview.py
@@ -71,6 +71,7 @@ class WebView(Widget):
         self.native.UIDelegate = self.native
 
         self.native.allowsLinkPreview = False
+        self.native.scrollView.setContentInsetAdjustmentBehavior(2);
 
         self.loaded_future = None
 


### PR DESCRIPTION
This is necessary for the `minor-ui-improvements` branch in `storytime`